### PR TITLE
fix: ensure responsive SVG chart dimensions

### DIFF
--- a/src/view/components/metrics/parts/metrics-chart/metrics-chart.vue
+++ b/src/view/components/metrics/parts/metrics-chart/metrics-chart.vue
@@ -135,6 +135,7 @@
       :viewBox="`0 0 ${chartWidth} 48`"
       role="img"
       :aria-label="ariaLabel"
+      style="width: 100%; max-width: 100%; height: auto"
       @mousemove="emit('chart-mousemove', $event)"
       @mouseleave="emit('chart-mouseleave')"
     >
@@ -156,6 +157,7 @@
       :viewBox="`0 0 ${chartWidth} 48`"
       role="img"
       :aria-label="ariaLabel"
+      style="width: 100%; max-width: 100%; height: auto"
       @mousemove="emit('chart-mousemove', $event)"
       @mouseleave="emit('chart-mouseleave')"
     >
@@ -187,6 +189,7 @@
     <svg
       v-else-if="type === 'status'"
       :viewBox="`0 0 ${chartWidth} 48`"
+      style="width: 100%; max-width: 100%; height: auto"
       role="img"
       :aria-label="ariaLabel"
     >
@@ -238,6 +241,7 @@
       :viewBox="`0 0 ${chartWidth} 48`"
       role="img"
       :aria-label="ariaLabel"
+      style="width: 100%; max-width: 100%; height: auto"
       @mousemove="emit('chart-mousemove', $event)"
       @mouseleave="emit('chart-mouseleave')"
     >


### PR DESCRIPTION
This pull request improves the responsiveness of the metrics chart component by ensuring that all SVG chart elements scale correctly within their containers. The main change is the addition of inline styles to set the SVG width to 100%, with a maximum width of 100% and automatic height adjustment.

**Responsiveness Improvements:**

* Added `style="width: 100%; max-width: 100%; height: auto"` to all SVG elements in `metrics-chart.vue` to ensure charts resize properly within their containers. [[1]](diffhunk://#diff-c278d8a7628aadcceaa51ac79f3483e00dad22a6b6a6f4d3f8700a9f2d2ac49aR138) [[2]](diffhunk://#diff-c278d8a7628aadcceaa51ac79f3483e00dad22a6b6a6f4d3f8700a9f2d2ac49aR160) [[3]](diffhunk://#diff-c278d8a7628aadcceaa51ac79f3483e00dad22a6b6a6f4d3f8700a9f2d2ac49aR192) [[4]](diffhunk://#diff-c278d8a7628aadcceaa51ac79f3483e00dad22a6b6a6f4d3f8700a9f2d2ac49aR244)